### PR TITLE
Enabled costum reasoner configurations

### DIFF
--- a/src/main/java/org/semanticweb/owl/explanation/impl/blackbox/checker/ConsistencyEntailmentCheckerFactory.java
+++ b/src/main/java/org/semanticweb/owl/explanation/impl/blackbox/checker/ConsistencyEntailmentCheckerFactory.java
@@ -1,11 +1,9 @@
 package org.semanticweb.owl.explanation.impl.blackbox.checker;
 
-import org.semanticweb.owl.explanation.impl.blackbox.EntailmentCheckerFactory;
-
 import java.util.function.Supplier;
 
 import org.semanticweb.owl.explanation.impl.blackbox.EntailmentChecker;
-import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.semanticweb.owl.explanation.impl.blackbox.EntailmentCheckerFactory;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 /*
@@ -31,6 +29,9 @@ import org.semanticweb.owlapi.model.OWLDataFactory;
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.reasoner.OWLReasonerConfiguration;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.semanticweb.owlapi.reasoner.SimpleConfiguration;
 
 /**
  * Author: Matthew Horridge<br>
@@ -40,27 +41,34 @@ import org.semanticweb.owlapi.model.OWLOntologyManager;
  */
 public class ConsistencyEntailmentCheckerFactory implements EntailmentCheckerFactory<OWLAxiom> {
 
-    private OWLReasonerFactory reasonerFactory;
+	private final OWLDataFactory df;
 
-    private long timeout = Long.MAX_VALUE;
+	private final Supplier<OWLOntologyManager> m;
 
-    private OWLDataFactory df;
+	private final Supplier<OWLReasonerConfiguration> rC;
 
-    private Supplier<OWLOntologyManager> m;
+	private final OWLReasonerFactory reasonerFactory;
 
 //    public ConsistencyEntailmentCheckerFactory(OWLReasonerFactory reasonerFactory) {
 //        this(reasonerFactory, Long.MAX_VALUE);
 //    }
 
-    public ConsistencyEntailmentCheckerFactory(OWLReasonerFactory reasonerFactory, Supplier<OWLOntologyManager> m, OWLDataFactory df, long timeout) {
-        this.reasonerFactory = reasonerFactory;
-        this.timeout = timeout;
-        this.df = df;
-        this.m = m;
-    }
+	public ConsistencyEntailmentCheckerFactory(final OWLReasonerFactory reasonerFactory,
+			final Supplier<OWLOntologyManager> m, final OWLDataFactory df, final long timeout) {
+		this(reasonerFactory, m, df, () -> new SimpleConfiguration(timeout));
+	}
 
-    @Override
-    public EntailmentChecker<OWLAxiom> createEntailementChecker(OWLAxiom entailment) {
-        return new ConsistencyEntailmentChecker(reasonerFactory, m, df, timeout);
-    }
+	public ConsistencyEntailmentCheckerFactory(final OWLReasonerFactory reasonerFactory,
+			final Supplier<OWLOntologyManager> m, final OWLDataFactory df,
+			final Supplier<OWLReasonerConfiguration> rC) {
+		this.reasonerFactory = reasonerFactory;
+		this.df = df;
+		this.m = m;
+		this.rC = rC;
+	}
+
+	@Override
+	public EntailmentChecker<OWLAxiom> createEntailementChecker(final OWLAxiom entailment) {
+		return new ConsistencyEntailmentChecker(reasonerFactory, m, df, rC);
+	}
 }

--- a/src/main/java/org/semanticweb/owl/explanation/impl/blackbox/checker/InconsistentOntologyExplanationGeneratorFactory.java
+++ b/src/main/java/org/semanticweb/owl/explanation/impl/blackbox/checker/InconsistentOntologyExplanationGeneratorFactory.java
@@ -1,20 +1,5 @@
 package org.semanticweb.owl.explanation.impl.blackbox.checker;
 
-import org.semanticweb.owlapi.model.OWLAxiom;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
-import org.semanticweb.owlapi.model.parameters.Imports;
-import org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory;
-import org.semanticweb.owl.explanation.api.ExplanationGenerator;
-import org.semanticweb.owl.explanation.api.ExplanationProgressMonitor;
-import org.semanticweb.owl.explanation.api.NullExplanationProgressMonitor;
-import org.semanticweb.owl.explanation.impl.blackbox.*;
-import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
-
-import java.util.Set;
-import java.util.function.Supplier;
-
 import static org.semanticweb.owlapi.util.OWLAPIStreamUtils.add;
 
 import java.util.HashSet;
@@ -40,6 +25,25 @@ import java.util.HashSet;
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.semanticweb.owl.explanation.api.ExplanationGenerator;
+import org.semanticweb.owl.explanation.api.ExplanationGeneratorFactory;
+import org.semanticweb.owl.explanation.api.ExplanationProgressMonitor;
+import org.semanticweb.owl.explanation.api.NullExplanationProgressMonitor;
+import org.semanticweb.owl.explanation.impl.blackbox.BlackBoxExplanationGenerator2;
+import org.semanticweb.owl.explanation.impl.blackbox.ExpansionStrategy;
+import org.semanticweb.owl.explanation.impl.blackbox.InconsistentOntologyContractionStrategy;
+import org.semanticweb.owl.explanation.impl.blackbox.InconsistentOntologyExpansionStrategy;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.parameters.Imports;
+import org.semanticweb.owlapi.reasoner.OWLReasonerConfiguration;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.semanticweb.owlapi.reasoner.SimpleConfiguration;
 
 /**
  * Author: Matthew Horridge<br>
@@ -49,54 +53,51 @@ import java.util.HashSet;
  */
 public class InconsistentOntologyExplanationGeneratorFactory implements ExplanationGeneratorFactory<OWLAxiom> {
 
+	private final ConsistencyEntailmentCheckerFactory consistencyEntailmentCheckerFactory;
 
-    private InconsistentOntologyContractionStrategy<OWLAxiom> contractionStrategy;
+	private final InconsistentOntologyContractionStrategy<OWLAxiom> contractionStrategy;
 
-    private ExpansionStrategy<OWLAxiom> expansionStrategy;
+	private final ExpansionStrategy<OWLAxiom> expansionStrategy;
 
-    private ConsistencyEntailmentCheckerFactory consistencyEntailmentCheckerFactory;
+	private final Supplier<OWLOntologyManager> m;
 
-    private Supplier<OWLOntologyManager> m;
+	public InconsistentOntologyExplanationGeneratorFactory(final OWLReasonerFactory reasonerFactory,
+			final OWLDataFactory df, final Supplier<OWLOntologyManager> m, final long entailmentCheckingTimeout) {
+		this(reasonerFactory, df, m, () -> new SimpleConfiguration(entailmentCheckingTimeout));
+	}
 
-    public InconsistentOntologyExplanationGeneratorFactory(OWLReasonerFactory reasonerFactory, OWLDataFactory df, Supplier<OWLOntologyManager> m, long entailmentCheckingTimeout) {
-        expansionStrategy = new InconsistentOntologyExpansionStrategy<>();
-        contractionStrategy = new InconsistentOntologyContractionStrategy<>();
-        this.m = m;
-        consistencyEntailmentCheckerFactory = new ConsistencyEntailmentCheckerFactory(reasonerFactory, m, df, entailmentCheckingTimeout);
-    }
+	public InconsistentOntologyExplanationGeneratorFactory(final OWLReasonerFactory reasonerFactory,
+			final OWLDataFactory df, final Supplier<OWLOntologyManager> m,
+			final Supplier<OWLReasonerConfiguration> rC) {
+		expansionStrategy = new InconsistentOntologyExpansionStrategy<>();
+		contractionStrategy = new InconsistentOntologyContractionStrategy<>();
+		this.m = m;
+		consistencyEntailmentCheckerFactory = new ConsistencyEntailmentCheckerFactory(reasonerFactory, m, df, rC);
+	}
 
+	@Override
+	public ExplanationGenerator<OWLAxiom> createExplanationGenerator(final OWLOntology ontology) {
+		return createExplanationGenerator(ontology, new NullExplanationProgressMonitor<OWLAxiom>());
+	}
 
-    @Override
-    public ExplanationGenerator<OWLAxiom> createExplanationGenerator(OWLOntology ontology) {
-        return createExplanationGenerator(ontology, new NullExplanationProgressMonitor<OWLAxiom>());
-    }
+	@Override
+	public ExplanationGenerator<OWLAxiom> createExplanationGenerator(final OWLOntology ontology,
+			final ExplanationProgressMonitor<OWLAxiom> progressMonitor) {
+		final Set<OWLAxiom> axioms = new HashSet<>(ontology.getLogicalAxiomCount(Imports.INCLUDED));
+		ontology.importsClosure().forEach(ont -> add(axioms, ont.logicalAxioms()));
+		return new BlackBoxExplanationGenerator2<>(axioms, consistencyEntailmentCheckerFactory, expansionStrategy,
+				contractionStrategy, progressMonitor, m);
+	}
 
-    @Override
-    public ExplanationGenerator<OWLAxiom> createExplanationGenerator(OWLOntology ontology, ExplanationProgressMonitor<OWLAxiom> progressMonitor) {
-        Set<OWLAxiom> axioms = new HashSet<>(ontology.getLogicalAxiomCount(Imports.INCLUDED));
-        ontology.importsClosure().forEach(ont -> add(axioms, ont.logicalAxioms()));
-        return new BlackBoxExplanationGenerator2<>(
-                axioms,
-                consistencyEntailmentCheckerFactory,
-                expansionStrategy,
-                contractionStrategy,
-                progressMonitor,
-                m);
-    }
+	@Override
+	public ExplanationGenerator<OWLAxiom> createExplanationGenerator(final Set<? extends OWLAxiom> axioms) {
+		return createExplanationGenerator(axioms, new NullExplanationProgressMonitor<OWLAxiom>());
+	}
 
-    @Override
-    public ExplanationGenerator<OWLAxiom> createExplanationGenerator(Set<? extends OWLAxiom> axioms) {
-        return createExplanationGenerator(axioms, new NullExplanationProgressMonitor<OWLAxiom>());
-    }
-
-    @Override
-    public ExplanationGenerator<OWLAxiom> createExplanationGenerator(Set<? extends OWLAxiom> axioms, ExplanationProgressMonitor<OWLAxiom> progressMonitor) {
-        return new BlackBoxExplanationGenerator2<>(
-                axioms,
-                consistencyEntailmentCheckerFactory,
-                expansionStrategy,
-                contractionStrategy,
-                progressMonitor,
-                m);
-    }
+	@Override
+	public ExplanationGenerator<OWLAxiom> createExplanationGenerator(final Set<? extends OWLAxiom> axioms,
+			final ExplanationProgressMonitor<OWLAxiom> progressMonitor) {
+		return new BlackBoxExplanationGenerator2<>(axioms, consistencyEntailmentCheckerFactory, expansionStrategy,
+				contractionStrategy, progressMonitor, m);
+	}
 }


### PR DESCRIPTION
I had a problem using the explanation code together with the new OWL API 5 OWLlink (btw, thank you very much for that):
The `OWLlinkHTTPXMLReasonerFactory` only allows an `OWLlinkReasonerConfiguration`, but `ConsistencyEntailmentChecker` used `SimpleConfiguration` by default. I added a constructor that takes a `Supplier<OWLReasonerConfiguration>` to solve this.

Cheers,
Robin